### PR TITLE
Adds missing AWS policy and another note to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,27 @@ You can read about this architecture in the Heroku Dev Center article: [Peering 
     With policies:
     * **AmazonVPCFullAccess**
     * **AmazonRedshiftFullAccess**
+    * And a policy [granting iam:CreateServiceLinkedRole](https://docs.aws.amazon.com/IAM/latest/UserGuide/using-service-linked-roles.html#service-linked-role-permissions) such as:
+      ```
+      {
+          "Version": "2012-10-17",
+          "Statement": [
+              {
+                  "Effect": "Allow",
+                  "Action": "iam:CreateServiceLinkedRole",
+                  "Resource": "arn:aws:iam::*:role/aws-service-role/*"
+              },
+              {
+                  "Effect": "Allow",
+                  "Action": [
+                      "iam:AttachRolePolicy",
+                      "iam:PutRolePolicy"
+                  ],
+                  "Resource": "arn:aws:iam::*:role/aws-service-role/*"
+              }
+          ]
+      }
+      ```
 
 ## Config
 
@@ -66,7 +87,7 @@ export \
 terraform init
 ```
 
-Choose a deployment name. Keep it short as your resources will be prefixed by the chosen name.
+Choose a deployment name. Keep it short (under 14 characters) as your resources will be prefixed by the chosen name.
 ```
 terraform apply \
   -var name=<your-deployment-name> \


### PR DESCRIPTION
I found this repo when following https://blog.heroku.com/event-streams-kafka-redshift-metabase#real-time-product-analytics-using-amazon-redshift-and-metabase (Using version 1d1df6b BTW)

I had problems when running `terraform apply` because I was missing the `iam:CreateServiceLinkedRole` permission in AWS. I'm adding info to the README.md to include that note as well as another small issue I had with the length of the deployment name (limited to 14 because resource `heroku_app.redshift_client` prepends 16 characters to it and it's limited to 30 total).